### PR TITLE
adapted the code to compile with gcc7. No functional changes

### DIFF
--- a/GitCommand/Add.h
+++ b/GitCommand/Add.h
@@ -16,6 +16,10 @@
 
 #include <git2.h>
 
+//#if __GNUC__ > 2
+	using std::vector;
+//#endif	
+
 
 /**
  * Add command Class.

--- a/GitCommand/SwitchBranch.h
+++ b/GitCommand/SwitchBranch.h
@@ -14,6 +14,11 @@
 
 #include <vector>
 
+//#if __GNUC__ > 2
+	using std::vector;
+//#endif	
+
+
 /**
  * Switch Branch command Class.
  */

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ RSRCS =
 #	- 	if your library does not follow the standard library naming scheme,
 #		you need to specify the path to the library and it's name.
 #		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
-LIBS = be tracker git2 localestub
+LIBS = $(STDCPPLIBS) be tracker git2 localestub
 
 #	Specify additional paths to directories following the standard libXXX.so
 #	or libXXX.a naming scheme. You can specify full paths or paths relative

--- a/TrackGitApp.h
+++ b/TrackGitApp.h
@@ -13,6 +13,10 @@
 #include <AppKit.h>
 #include <SupportKit.h>
 
+//#if __GNUC__ > 2
+	using std::map;
+//#endif	
+
 class TrackGitWindow;
 
 

--- a/Utils.h
+++ b/Utils.h
@@ -14,7 +14,7 @@
 #include <AppKit.h>
 #include <SupportKit.h>
 
-#include <vector.h>
+#include <vector>
 #include <git2.h>
 
 #define CANCEL_CREDENTIALS -123
@@ -45,6 +45,12 @@ enum {
  * The Application signature.
  */
 #define APP_SIGN "application/x-vnd.Haiku-TrackGit"
+
+
+//#if __GNUC__ > 2
+	using std::vector;
+//#endif	
+
 
 void extract_selected_paths(const BMessage* msg,
 		vector<char*>& selected);


### PR DESCRIPTION
I added #if __GNUC__ > 2 in a few places where needed and imported std::vector into the global namespace to get the code to compile with both gcc2 and gcc7. 
The linking process failed with symbols missing from libstdc++ and libsupc++ so I added them to them Makefile with $(STDCPPLIBS)

Tested on x86_64 nightly (with gcc7) and on x86_gcc2 Beta 1 (with gcc2). It also compiles on x86_gcc2 with gcc7 but the add-on doesn't work with tracker (I think due to ABI issues because Tracker is compiled with gcc2)

Andi Machovec (BlueSky)