### PR TITLE
uncommented preprocessor directives from the gcc7 fix.

### DIFF
--- a/GitCommand/Add.h
+++ b/GitCommand/Add.h
@@ -16,9 +16,9 @@
 
 #include <git2.h>
 
-//#if __GNUC__ > 2
+#if __GNUC__ > 2
 	using std::vector;
-//#endif	
+#endif	
 
 
 /**

--- a/GitCommand/SwitchBranch.h
+++ b/GitCommand/SwitchBranch.h
@@ -14,9 +14,9 @@
 
 #include <vector>
 
-//#if __GNUC__ > 2
+#if __GNUC__ > 2
 	using std::vector;
-//#endif	
+#endif	
 
 
 /**

--- a/TrackGitApp.h
+++ b/TrackGitApp.h
@@ -13,9 +13,9 @@
 #include <AppKit.h>
 #include <SupportKit.h>
 
-//#if __GNUC__ > 2
+#if __GNUC__ > 2
 	using std::map;
-//#endif	
+#endif	
 
 class TrackGitWindow;
 

--- a/Utils.h
+++ b/Utils.h
@@ -47,9 +47,9 @@ enum {
 #define APP_SIGN "application/x-vnd.Haiku-TrackGit"
 
 
-//#if __GNUC__ > 2
+#if __GNUC__ > 2
 	using std::vector;
-//#endif	
+#endif	
 
 
 void extract_selected_paths(const BMessage* msg,


### PR DESCRIPTION
I have accidentally left the preprocessor directives commented out. That came from some previous experimenting. GCC2 doesn't seem to mind but it is still wrong so I corrected it. 