### PR TITLE
Log window tweaks, append logs while loading

### DIFF
--- a/GitCommand/Log.h
+++ b/GitCommand/Log.h
@@ -1,19 +1,18 @@
-/**
- * @file Log.h
- * @brief Header file of Log command.
- * 
- * @author Hrishikesh Hiraskar <hrishihiraskar@gmail.com>
+/*
+ * Copyright 2018, Hrishikesh Hiraskar <hrishihiraskar@gmail.com>
+ * All rights reserved. Distributed under the terms of the MIT license.
  */
 
 #ifndef _LOG_H_
 #define _LOG_H_
 
-#include "GitCommand.h"
-#include "../UI/LogWindow.h"
-
 #include <SupportKit.h>
 
 #include <git2.h>
+
+#include "GitCommand.h"
+#include "../UI/LogWindow.h"
+
 
 /**
  * log_state represents walker being configured while handling options
@@ -60,7 +59,7 @@ public:
 							Log(BString);
 
 	virtual	void			Execute();
-	BString					GetLogText();
+			void			AppendLogText();
 	virtual TrackGitWindow*	GetWindow();
 };
 

--- a/UI/LogWindow.cpp
+++ b/UI/LogWindow.cpp
@@ -1,23 +1,15 @@
-/**
- * @file LogWindow.cpp
- * @brief Implementation file of Log window.
- * 
- * @author Hrishikesh Hiraskar <hrishihiraskar@gmail.com>
+/*
+ * Copyright 2018, Hrishikesh Hiraskar <hrishihiraskar@gmail.com>
+ * All rights reserved. Distributed under the terms of the MIT license.
  */
 
 #include "LogWindow.h"
 
-#include <stdio.h>
-
 #include <Catalog.h>
 #include <LayoutBuilder.h>
+#include <Screen.h>
 
-#define B_TRANSLATION_CONTEXT "TrackGit"
-
-
-enum {
-	kOK
-};
+#define B_TRANSLATION_CONTEXT "Log Window"
 
 
 /**
@@ -26,24 +18,23 @@ enum {
  */
 LogWindow::LogWindow(BString repo)
 	:
-	TrackGitWindow(repo, BRect(0, 0, 400, 300), "TrackGit - Log",
+	TrackGitWindow(repo, window_rect_by_text_column(80),
+			B_TRANSLATE("TrackGit - Log"),
 			B_TITLED_WINDOW, B_NOT_RESIZABLE | B_NOT_ZOOMABLE)
 {
 	fLogTextView = new BTextView("logText");
-	fLogTextView->SetText("Loading...");
+	fLogTextView->SetText(B_TRANSLATE("Loading" B_UTF8_ELLIPSIS));
 	fLogTextView->MakeEditable(false);
+
+	fLoading = true;
 	
 	BScrollView* fScrollView = new BScrollView("logScrollView",
 			fLogTextView, B_WILL_DRAW | B_FRAME_EVENTS, false, true,
 			B_PLAIN_BORDER);
 
-	BButton* fOK = new BButton("ok", B_TRANSLATE("OK"),
-			new BMessage(kOK));
-
 	BLayoutBuilder::Group<>(this, B_VERTICAL)
 		.SetInsets(B_USE_WINDOW_INSETS)
-		.Add(fScrollView)
-		.Add(fOK);
+		.Add(fScrollView);
 
 	CenterOnScreen();
 	Show();
@@ -51,31 +42,33 @@ LogWindow::LogWindow(BString repo)
 
 
 /**
- * Sets Text of the View in Window.
- * @param text The text to be set.
+ * Appends text to the View in Window.
+ * @param text Text to be appended
  */
 void
-LogWindow::SetText(BString text)
+LogWindow::AppendText(BString text)
 {
 	if (LockLooper()) {
-		fLogTextView->SetText(text.String());
+		if (fLoading == true) {
+			fLogTextView->SetText(text);
+			fLoading = false;
+		}
+		else
+			fLogTextView->Insert(fLogTextView->TextLength(), text.String(), text.Length());
 		UnlockLooper();
 	}
 }
 
 
-/**
- * Handler to received messages.
- * @param msg The received message.
- */
-void
-LogWindow::MessageReceived(BMessage* msg)
+BRect
+window_rect_by_text_column(int32 columns)
 {
-	switch (msg->what) {
-		case kOK:
-			Quit();
-			break;
-		default:
-			BWindow::MessageReceived(msg);
-	}
+	int32 width = (be_plain_font->StringWidth("x") * columns) + 10;
+	int32 height = 0.9 * width;
+
+	BRect screen = BScreen().Frame();
+	if (screen.Width() < width || screen.Height() < height)
+		return BRect(0, 0, 400, 300);
+	else
+		return BRect(0, 0, width, height);
 }

--- a/UI/LogWindow.h
+++ b/UI/LogWindow.h
@@ -1,31 +1,31 @@
-/**
- * @file LogWindow.h
- * @brief Header file of Log window.
- * 
- * @author Hrishikesh Hiraskar <hrishihiraskar@gmail.com>
+/*
+ * Copyright 2018, Hrishikesh Hiraskar <hrishihiraskar@gmail.com>
+ * All rights reserved. Distributed under the terms of the MIT license.
  */
 
 #ifndef _LOG_WINDOW_H_
 #define _LOG_WINDOW_H_
 
-#include "TrackGitWindow.h"
-
 #include <InterfaceKit.h>
 #include <SupportKit.h>
+
+#include "TrackGitWindow.h"
 
 
 /**
  * The Log Window class.
  */
 class LogWindow : public TrackGitWindow {
-	/**
-	 * The Log Text View.
-	 */
-	BTextView* fLogTextView;
 public:
-	LogWindow(BString);
-	void SetText(BString);
-	virtual void MessageReceived(BMessage*);
+					LogWindow(BString);
+			void	AppendText(BString);
+
+private:
+	bool fLoading;
+	BTextView* fLogTextView;
 };
+
+
+BRect window_rect_by_text_column(int32 columns);
 
 #endif


### PR DESCRIPTION
Slight redesign of the log window for readability (bases the window size on column-size of 80, removes "OK" button). Also appends logs in clumps rather than all at once, which leads to the haiku repo's logs showing up about ~4sec faster on my machine.